### PR TITLE
race render to cause failure

### DIFF
--- a/packages/nexrender-worker/src/index.js
+++ b/packages/nexrender-worker/src/index.js
@@ -85,7 +85,7 @@ const start = async (host, secret, settings) => {
                 }
             }
 
-            job = Promise.race([
+            job = await Promise.race([
                 waitAndThrow(NEXRENDER_TIMEOUT, 'render timeout'),
                 render(job, settings)
             ]);

--- a/packages/nexrender-worker/src/index.js
+++ b/packages/nexrender-worker/src/index.js
@@ -5,6 +5,7 @@ const rimraf = require('rimraf')
 
 const NEXRENDER_API_POLLING = process.env.NEXRENDER_API_POLLING || 30 * 1000;
 const NEXRENDER_MAX_RETRIES = process.env.NEXRENDER_MAX_RETRIES || 2
+const NEXRENDER_TIMEOUT = process.env.NEXRENDER_TIMEOUT || 1000 * 60 * 30 // 30 minutes
 
 /* TODO: possibly add support for graceful shutdown */
 let active = true;
@@ -12,6 +13,14 @@ let active = true;
 const delay = amount => (
     new Promise(resolve => setTimeout(resolve, amount))
 )
+
+const waitAndThrow = (ms, errorMessage) => {
+    return new Promise((_, reject) => {
+        setTimeout(() => {
+            reject(errorMessage);
+        }, ms);
+    });
+};
 
 const nextJob = async (client, settings) => {
     do {
@@ -76,10 +85,12 @@ const start = async (host, secret, settings) => {
                 }
             }
 
-            job = await render(job, settings); {
-                job.state = 'finished';
-                job.finishedAt = new Date()
-            }
+            job = Promise.race([
+                waitAndThrow(NEXRENDER_TIMEOUT, 'render timeout'),
+                render(job, settings)
+            ]);
+            job.state = 'finished';
+            job.finishedAt = new Date()
 
             await client.updateJob(job.uid, getRenderingStatus(job))
         } catch (err) {


### PR DESCRIPTION
Race render promise to allow failure if render takes too long. Default timeout is 30 minutes but this value can be adjusted with `NEXRENDER_TIMEOUT`