### PR TITLE
CR-4710 - Add ability to add a job without events

### DIFF
--- a/packages/nexrender-api/src/job.js
+++ b/packages/nexrender-api/src/job.js
@@ -57,12 +57,19 @@ module.exports = (fetch, polling) => ({
         return fetch(`/jobs/pickup?${params}`)
     },
 
-    addJob: async data =>
-        withEventEmitter(fetch, await fetch(`/jobs`, {
+    addJob: async (data, options = {withEvents: true}) => {
+        const fetchJobs = fetch(`/jobs`, {
             method: 'post',
             headers: {'content-type': 'application/json'},
             body: JSON.stringify(data),
-        }), polling),
+        })
+
+        if (options.withEvents) {
+            return withEventEmitter(fetch, await fetchJobs, polling)
+        }
+
+        return fetchJobs
+    },
 
     resumeJob: async id =>
         withEventEmitter(fetch, await fetch(`/jobs/${id}`), polling),

--- a/packages/nexrender-api/test/manual.js
+++ b/packages/nexrender-api/test/manual.js
@@ -1,7 +1,7 @@
 const { createClient } = require('../src')
 
 const client = createClient({
-    host: 'http://localhost:3050',
+    host: 'http://localhost:3000',
     secret: 'myapisecret',
 })
 
@@ -19,25 +19,25 @@ const job = {
             type: 'image',
             provider: 'file',
             src: '/Users/inlife/Downloads/nexrender-boilerplate-master/assets/2016-aug-deep.jpg',
-            layer: 'background.jpg',
+            layerName: 'background.jpg',
         },
         {
             type: 'image',
             provider: 'file',
             src: '/Users/inlife/Downloads/nexrender-boilerplate-master/assets/nm.png',
-            layer: 'nm.png',
+            layerName: 'nm.png',
         },
         {
             type: 'audio',
             provider: 'file',
             src: '/Users/inlife/Downloads/nexrender-boilerplate-master/assets/deep_60s.mp3',
-            layer: 'audio.mp3',
+            layerName: 'audio.mp3',
         },
     ],
     // onChange: (job, state) => console.log('new job state', state)
 }
 
-
+// Test with events
 client.addJob(job).then(result => {
     result.on('created', (/* job */) => {
         console.log('project has been created')
@@ -55,6 +55,14 @@ client.addJob(job).then(result => {
     result.on('error', (/* err */) => {
         console.log('project rendering error');
     })
+}).catch(err => {
+    console.log('job creation error:')
+    console.log(err.stack)
+})
+
+// Test without events
+client.addJob(job, {withEvents: false}).then(job => {
+    console.log('job', job)
 }).catch(err => {
     console.log('job creation error:')
     console.log(err.stack)


### PR DESCRIPTION
https://ld-create.atlassian.net/browse/CR-4709

**Problem**

By default, when calling `client.addJob` it wraps the request in an event emitter, which polls the job status every configured interval and emits events when the job updates, errors or completes.

We've found that when a lot of analysis jobs are triggered around the same time, it causes performance issues as we're subsequently polling for each new job. This causes some jobs to sit in pending as they're never added to the Redis queue.

We've also found in the Lambda logs on `triggerAnalysisJob` have a mix of events emitted from other jobs, which causes confusion.

**Solution**

As we call `addJob` from Lambda, we don't need to poll for events. It should be a simple fire and forget.

I've added a new `withEvents` option which defaults to `true` for backwards compatibility.

Once this is merged and published, we can update the Lambdas to pass this new flag.

**Tests**

I've tested this locally:

Default (with events) still emits as expected:

<img width="727" alt="Screenshot 2023-05-10 at 13 46 42" src="https://github.com/create-global/nexrender/assets/3315022/0600385e-e23c-4c91-99b7-1e93660e7ebf">

withEvents: false returns the job and does not emit events.

<img width="806" alt="Screenshot 2023-05-10 at 13 48 21" src="https://github.com/create-global/nexrender/assets/3315022/bd130c10-dcc4-41f2-95e7-3cf4caef221d">

