### PR TITLE
CR-4841 Spread picked jobs across clients

### DIFF
--- a/packages/nexrender-server/src/routes/jobs-pickup.js
+++ b/packages/nexrender-server/src/routes/jobs-pickup.js
@@ -39,6 +39,20 @@ module.exports = async (req, res) => {
                 if (isNaN(b.priority)) b.priority = 0
                 return b.priority - a.priority
             })[0]
+        } else if (process.env.NEXRENDER_ORDERING === 'stage-distributed') {
+            const jobs = Object.values(queued.reduce((res, item) => {
+                const stage = item.ct?.attributes?.stage || 'no-stage';
+                if (!res[stage]) {
+                    return {
+                        ...res,
+                        [stage]: item
+                    };
+                }
+                return res;
+            }, {}))
+
+            // pick random
+            job = jobs[Math.floor(Math.random() * jobs.length)];
         }
         else { /* fifo (oldest-first) */
             job = queued[0];


### PR DESCRIPTION
## Pull request

**[Jira Ticket](https://ld-create.atlassian.net/browse/CR-4841)**

**Description:**
Picking next job based on client + creation date, instead of only creation date (FIFO)

Alternative implementations here:
https://github.com/create-global/nexrender/pull/17
https://github.com/create-global/automation-bridge-worker/pull/19
