### PR TITLE
CR-5674 - Increase fetch all jobs size limit

### DIFF
--- a/packages/nexrender-server/src/routes/jobs-fetch.js
+++ b/packages/nexrender-server/src/routes/jobs-fetch.js
@@ -31,12 +31,11 @@ const fetchAllJobs = async (page = 1, size = 20, types = [],) => {
     const results = await fetch(null, types)
     const total = results.length
 
-    const paginatedResults = page ?
+    const paginatedResults =
         paginate(results, {
             page: clamp(page, {min: 1}),
             size: clamp(size, {min: 1, max: 2000})
         })
-        : results
 
     return transformResults(paginatedResults, {page, size, total})
 }

--- a/packages/nexrender-server/src/routes/jobs-fetch.js
+++ b/packages/nexrender-server/src/routes/jobs-fetch.js
@@ -34,7 +34,7 @@ const fetchAllJobs = async (page = 1, size = 20, types = [],) => {
     const paginatedResults = page ?
         paginate(results, {
             page: clamp(page, {min: 1}),
-            size: clamp(size, {min: 1, max: 30})
+            size: clamp(size, {min: 1, max: 2000})
         })
         : results
 


### PR DESCRIPTION
The Automation UI currently sends a `?page=0&size=10000` request.

The fetch job logic sees the `page=0` and so attempts to return all records, which in turn causes a HTTP 413 Lambda error due to reaching a response limit.

We know we can happily show ~2000 records, so I've increased this to the max (from 30) that can be requested.

I will then update the Automation UI to request the first page and a size of 2000, so we will always display the latest 2000 records without the request failing.