### PR TITLE
CR-5947 Explicitly resolve database-provider modules 

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "1.51.5"
+  "version": "1.52.0"
 }

--- a/packages/nexrender-server/package-lock.json
+++ b/packages/nexrender-server/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@create-global/nexrender-server",
-  "version": "1.51.4",
+  "version": "1.52.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/nexrender-server/package.json
+++ b/packages/nexrender-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@create-global/nexrender-server",
-  "version": "1.51.4",
+  "version": "1.52.0",
   "author": "inlife",
   "main": "src/index.js",
   "scripts": {

--- a/packages/nexrender-server/src/helpers/database.js
+++ b/packages/nexrender-server/src/helpers/database.js
@@ -1,5 +1,3 @@
-const requireg = require('requireg');
-
 const databaseType = process.env.NEXRENDER_DATABASE_PROVIDER;
 
 /* place to register all plugins */
@@ -8,8 +6,8 @@ if (process.env.NEXRENDER_REQUIRE_PLUGINS) {
     require('@create-global/nexrender-database-redis');
 }
 
-if (databaseType !== undefined) {
-    module.exports = requireg(`@create-global/nexrender-database-${databaseType}`);
+if (databaseType === 'redis') {
+    module.exports = require('@create-global/nexrender-database-redis');
 } else {
     module.exports = require('./disk.js');
 }


### PR DESCRIPTION
Using requireg for importing dynamic modules is anti-pattern, makes tree shaking extemely difficult and also lead to issues with JS bundlers like webpack/esbuild (that is used by default in serverless v4). So this PR changes the way we resolve database-provider (now we do it explicitly)

https://www.npmjs.com/package/requireg

<img width="881" alt="image" src="https://github.com/user-attachments/assets/90f07639-53f9-47db-b42b-40e18074cdf8">
